### PR TITLE
Patch to enable node archive mode

### DIFF
--- a/chain-scripts/golembase-op-geth-enable-archive-mode.patch
+++ b/chain-scripts/golembase-op-geth-enable-archive-mode.patch
@@ -1,0 +1,10 @@
+--- docker-compose.old	2025-11-14 14:56:24
++++ docker-compose.yml	2025-11-14 14:56:27
+@@ -22,6 +22,7 @@
+       --ws.addr '0.0.0.0' 
+       --ws.port 8545 
+       --datadir '/geth_data'
++      --gcmode archive
+     healthcheck:
+       test: ["CMD", "curl", "-f", "http://localhost:8545"]
+       interval: 5s

--- a/chain-scripts/start-dbchain.sh
+++ b/chain-scripts/start-dbchain.sh
@@ -11,6 +11,7 @@ cd ../../golembase-op-geth
 patch -N <../chain-scripts/golembase-op-geth-enable-txpool-api.patch || true
 patch -N <../chain-scripts/golembase-op-geth-rpclorer-external-port.patch || true
 patch -N <../chain-scripts/golembase-op-geth-all-interfaces.patch || true
+patch -N <../chain-scripts/golembase-op-geth-enable-archive-mode.patch || true
 docker compose up -d --build
 
 cd cmd/golembase


### PR DESCRIPTION
This adds another patch for `golembase-op-geth/docker-compose.yml` to enable archive mode for locally started node.